### PR TITLE
Feature: add nil* type

### DIFF
--- a/main.lisp
+++ b/main.lisp
@@ -1,3 +1,9 @@
 (in-package #:fakenil)
 
 (defconstant nil* 'nil*)
+
+(defun nil*p (object)
+  (eq object nil*))
+
+(deftype nil* ()
+  '(and symbol (satisfies nil*p)))


### PR DESCRIPTION
Now `nil*` can be used in type declarations/checking.

Alternatively, the predicate/type could be named `fakenilp` and `fakenil` respectively. What do you think is more apropriate? 